### PR TITLE
feat(schema): manage oneOf schema node

### DIFF
--- a/src/app/ui/forms/ui/ui.directive.js
+++ b/src/app/ui/forms/ui/ui.directive.js
@@ -80,12 +80,24 @@ function Controller($scope, $translate, events, modelManager, formService) {
         modelManager.validateModel(self.modelName, $scope.activeForm, $scope);
     }
 
+    // FIXME: when we use condition, the item is remove from the model. When the item come back it looses all the
+    // previously set info. We need a way to persist this info.
     function checkMenu(model, form) {
         self.showHelp = false;
         self.showAbout = false;
         model.forEach(item => {
-            if (item.includes('help')) self.showHelp = true;
-            if (item.includes('about')) self.showAbout = true;
+            if (item.includes('help')) {
+                self.showHelp = true;
+
+                // reset value to default beacuse when we remove about from the array aboutChoice is emptied
+                $scope.model.help = { 'folderName': 'default' };
+            }
+            if (item.includes('about')) {
+                self.showAbout = true;
+
+                // reset value to default beacuse when we remove about from the array aboutChoice is emptied
+                $scope.model.aboutChoice = 'string';
+            }
         })
     }
 
@@ -98,11 +110,11 @@ function Controller($scope, $translate, events, modelManager, formService) {
     }
 
     function isAboutString() {
-        return self.showAbout && $scope.model.aboutChoice === true;
+        return self.showAbout && $scope.model.aboutChoice === 'string';
     }
 
     function isAboutFolder() {
-        return self.showAbout && $scope.model.aboutChoice === false;
+        return self.showAbout && $scope.model.aboutChoice === 'folder';
     }
 
     function setForm() {
@@ -136,18 +148,19 @@ function Controller($scope, $translate, events, modelManager, formService) {
                     { 'key': 'sideMenu.logo' },
                     { 'key': 'logoUrl', 'condition': 'model.sideMenu.logo' },
                     { 'key': 'title' },
-                    { 'key': 'sideMenu.items', "add": $translate.instant('button.add'), 'onChange': checkMenu },
+                    { 'key': 'sideMenu.items', 'add': $translate.instant('button.add'), 'onChange': checkMenu },
                     { 'key': 'help', 'condition': isHelp },
-                    {   'key': 'aboutChoice',
-                        'type': 'radios',
-                        'condition': isAbout,
-                        'titleMap': [
-                            { 'value': true, 'name': "No I don't understand these cryptic terms" },
-                            { 'value': false, 'name': "Yes this makes perfect sense to me" }
-                        ]
-                    },
-                    { 'key': 'aboutString', 'condition': isAboutString },
-                    { 'key': 'aboutFolder', 'condition': isAboutFolder }
+                    { 'type': 'fieldset', 'title': $translate.instant('form.ui.about'), 'condition': isAbout,'items': [
+                        {   'key': 'aboutChoice',
+                            'type': 'select',
+                            'titleMap': [
+                                { 'value': "string", 'name': $translate.instant('form.ui.aboutstring') },
+                                { 'value': "folder", 'name': $translate.instant('form.ui.aboutfile') }
+                            ]
+                        },
+                        { 'key': 'about.content', 'condition': isAboutString },
+                        { 'key': 'about.folderName', 'condition': isAboutFolder }
+                    ]}
                 ] }
             ] }, {
                 'type': 'actions',

--- a/src/app/ui/header/header.directive.js
+++ b/src/app/ui/header/header.directive.js
@@ -146,24 +146,10 @@ function Controller($q, $mdDialog, events, modelManager, commonService) {
                 models[name] = modelManager.getModel(name, false);
             });
 
-            models = manageOneOf(models);
-
             // save the file
             const file = new File([JSON.stringify(models)], `${self.fileName}.json`, { type: 'text/plain' });
             FileSaver.saveAs(file);
             self.close();
-        }
-
-        /**
-         * Manage the case where we need to use oneOf. Use the choice value to apply the good object
-         * @function manageOneOf
-         * @param {Object} models all models
-         * @return {Object} models the updated model
-         */
-        function manageOneOf(models) {
-            models.ui.about = models.ui.aboutChoice ? models.ui.aboutString : models.ui.aboutFolder;
-
-            return models;
         }
     }
 }

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -25,7 +25,10 @@ summary preview dialog title,summary.previewdialog.title,Preview Viewer Configur
 form ui,form.ui.general,General,0,Générale,0
 form ui,form.ui.appbar,Application Bar,0,Barre d'application,0
 form ui,form.ui.navbar,Navigation Bar,0,Barre de navigation,0
-form ui,form.ui.sidemenu,Side Menu,0,Menu de coté,0
+form ui,form.ui.sidemenu,Side Menu,0,Menu latéral,0
+form ui,form.ui.about,About Map,0,A propos de cette carte,0
+form ui,form.ui.aboutstring,String content,0,Contenue dans du texte,0
+form ui,form.ui.aboutfile,File content,0,Contenue dans un fichier,0
 form service,form.service.urls,Service End Points,0,Liens pour les services,0
 form service,form.service.geosearch,Geo Search,0,Rechercher par endroits,0
 form service,form.service.export,Export Map,0,Exporter la carte,0

--- a/src/schemas/schemaForm/ui.en-CA.json
+++ b/src/schemas/schemaForm/ui.en-CA.json
@@ -149,40 +149,35 @@
             "description": "Will restrict the user from panning beyond the maximum extent.",
             "title": "Restrict Navigation"
         },
+        "about": {
+          "description": "About properties from configuration file or Markdown folder",
+          "title": "About Map",
+          "type": "object",
+          "subtype": "oneof",
+          "properties": {
+            "content": {
+                "description": "About properties from string content",
+                "title": "Content",
+                "type": "string",
+                "required": true
+            },
+            "folderName": {
+                "description": "About properties from configuration file or Markdown folder",
+                "title": "Folder Name",
+                "type": "string",
+                "required": true
+            },
+            "additionalProperties": false
+            }
+        },
         "aboutChoice": {
           "description": "",
-          "type": "bolean",
-          "enum": [true, false],
+          "type": "enum",
+          "enum": ["string", "folder"],
           "title": "About properties",
-          "default": true,
+          "default": "string",
           "required": true
-        },
-        "aboutString": {
-            "description": "About properties from configuration file or Markdown folder",
-            "type": "object",
-            "properties": {
-                "content": {
-                    "type": "string",
-                    "default": ""
-                }
-            },
-            "required": ["content"],
-            "additionalProperties": false,
-            "title": "About from String"
-        },
-        "aboutFolder": {
-            "description": "About properties from configuration file or Markdown folder",
-            "type": "object",
-                "properties": {
-                    "folderName": {
-                        "type": "string",
-                        "default": ""
-                    }
-            },
-            "required": ["folderName"],
-            "additionalProperties": false,
-            "title": "About from Folder"
-        },
+      },
         "help": {
             "type": "object",
             "description": "Help properties",


### PR DESCRIPTION
Closes #60

## Description
<!-- Link to an issue or include a description -->
Manage oneOf type. We create a selection node who contains the different node type. On selection of the type, the corresponding node appears (use form condition). It works great for simple case. We will see if we need to rethink it when we will do map form

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Chrome with simple case from ui part

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
Inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] ~~Release notes have been updated~~
- [x] PR targets the correct release version
- [ ] ~~Help files and documentation have been updated~~

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpa-apgf/65)
<!-- Reviewable:end -->
