### PR TITLE
feat(form): Add show advance congifuration and form validation global…

### DIFF
--- a/src/app/core/constant.service.js
+++ b/src/app/core/constant.service.js
@@ -36,7 +36,8 @@ function events($rootScope) {
         avSwitchLanguage: 'avSwitchLanguage', // Fired when there is a language switch
         avNewModel: 'avNewModel', // Fired when user create a new for
         avLoadModel: 'avLoadModel', // Fired when a user load an existing form
-        avNewItems: 'avNewItems' // Fired when a user add a new item inside an array (e.g. layer of layers)
+        avNewItems: 'avNewItems', // Fired when a user add a new item inside an array (e.g. layer of layers)
+        avValidateForm: 'avValidateForm' // Fired when a user click on validate to validate all forms
     };
 }
 

--- a/src/app/ui/forms/form.html
+++ b/src/app/ui/forms/form.html
@@ -1,8 +1,8 @@
 <div>
     <h3>{{ self.sectionName }}</h3>
     <md-checkbox aria-label="{{ 'form.showadvance' | translate }}" class="md-primary"
-        ng-model="self.advance"
-        ng-change="self.formService.showAdvance(self.modelName)">
+        ng-model="self.formService.advanceModel"
+        ng-change="self.formService.showAdvance()">
         {{ 'form.showadvance' | translate }}
     </md-checkbox>
     <form class="av-main-form av-form-{{ self.modelName }}" name="activeForm" sf-schema="schema" sf-form="form" sf-model="model" av-accordion></form>

--- a/src/app/ui/forms/form.service.js
+++ b/src/app/ui/forms/form.service.js
@@ -14,6 +14,7 @@ function formService(events, commonService) {
 
     const service = {
         showAdvance,
+        advanceModel: false,
         toggleSection,
         addToggleArraySection,
         copyValueToForm,
@@ -26,7 +27,8 @@ function formService(events, commonService) {
     /***/
 
     function showAdvance(form) {
-        const elems = document.getElementsByTagName(`av-${form}`)[0].getElementsByClassName('av-form-advance');
+        // manage the show advance configuration (add 'htmlClass': 'av-form-advance hidden' to fields who need advance config)
+        const elems = document.getElementsByClassName('av-form-advance');
 
         for (let elem of elems) {
             elem.classList.toggle('hidden');

--- a/src/app/ui/forms/map/map.directive.js
+++ b/src/app/ui/forms/map/map.directive.js
@@ -67,12 +67,10 @@ function Controller($scope, $translate, events, modelManager, formService, debou
         $scope.form = setForm();
     }
 
-    function validateForm() {
-        // First we broadcast an event so all fields validate themselves then we validate the model to update
-        // summary panel
+    events.$on(events.avValidateForm, () => {
         $scope.$broadcast('schemaFormValidate');
         modelManager.validateModel(self.modelName, $scope.activeForm, $scope);
-    }
+    });
 
     function copyValueToForm(model, item) {
         // change the $scope.form on the fly. May not work with specific index because it will change all of them at the same time
@@ -261,12 +259,7 @@ function Controller($scope, $translate, events, modelManager, formService, debou
                 { 'title': $translate.instant('form.map.legend'), 'items': [
 
                 ] }
-            ] }, {
-                'type': 'actions',
-                'items': [
-                    { 'type': 'button', 'style': 'btn-info', 'title': $translate.instant('button.validate'), 'onClick': validateForm }
-                ]
-            }
+            ] }
         ];
     }
 }

--- a/src/app/ui/forms/service/service.directive.js
+++ b/src/app/ui/forms/service/service.directive.js
@@ -45,9 +45,6 @@ function Controller($scope, $translate, events, modelManager, formService) {
     const self = this;
     self.modelName = 'service';
     self.sectionName = $translate.instant('app.section.service');
-
-    // manage the show advance configuration (add 'htmlClass': 'av-form-advance hidden' to fields who need advance config)
-    self.advance = false;
     self.formService = formService;
 
     // when schema is loaded or create new config is hit, initialize the schema, form and model
@@ -73,12 +70,10 @@ function Controller($scope, $translate, events, modelManager, formService) {
         $scope.form = setForm();
     }
 
-    function validateForm() {
-        // first we broadcast an event so all fields validate themselves then we validate the model to update
-        // summary panel
+    events.$on(events.avValidateForm, () => {
         $scope.$broadcast('schemaFormValidate');
         modelManager.validateModel(self.modelName, $scope.activeForm, $scope);
-    }
+    });
 
     function setForm() {
         return [
@@ -156,12 +151,7 @@ function Controller($scope, $translate, events, modelManager, formService) {
                         ] }
                     ] }
                 ] }
-            ] },
-            {
-                'type': 'actions',
-                'items': [
-                    { 'type': 'button', 'style': 'btn-info', 'title': $translate.instant('button.validate'), 'onClick': validateForm }
-                ]
-            }]
+            ] }
+        ];
     }
 }

--- a/src/app/ui/forms/ui/ui.directive.js
+++ b/src/app/ui/forms/ui/ui.directive.js
@@ -45,9 +45,6 @@ function Controller($scope, $translate, events, modelManager, formService) {
     const self = this;
     self.modelName = 'ui';
     self.sectionName = $translate.instant('app.section.ui');
-
-    // manage the show advance configuration (add 'htmlClass': 'av-form-advance hidden' to fields who need advance config)
-    self.advance = false;
     self.formService = formService;
 
     // when schema is loaded or create new config is hit, initialize the schema, form and model
@@ -73,12 +70,10 @@ function Controller($scope, $translate, events, modelManager, formService) {
         $scope.form = setForm();
     }
 
-    function validateForm() {
-        // First we broadcast an event so all fields validate themselves then we validate the model to update
-        // summary panel
+    events.$on(events.avValidateForm, () => {
         $scope.$broadcast('schemaFormValidate');
         modelManager.validateModel(self.modelName, $scope.activeForm, $scope);
-    }
+    });
 
     // FIXME: when we use condition, the item is remove from the model. When the item come back it looses all the
     // previously set info. We need a way to persist this info.
@@ -123,7 +118,7 @@ function Controller($scope, $translate, events, modelManager, formService) {
                 { 'title': $translate.instant('form.ui.general'), 'items': [
                     { 'key': 'fullscreen' },
                     { 'key': 'theme' },
-                    { 'key': 'failureFeedback' },
+                    { 'key': 'failureFeedback', 'htmlClass': 'av-form-advance hidden' },
                     {
                         'type': 'fieldset', 'title': 'Legend', 'items': [
                             { 'key': 'legend.reorderable' },
@@ -162,12 +157,7 @@ function Controller($scope, $translate, events, modelManager, formService) {
                         { 'key': 'about.folderName', 'condition': isAboutFolder }
                     ]}
                 ] }
-            ] }, {
-                'type': 'actions',
-                'items': [
-                    { 'type': 'button', 'style': 'btn-info', 'title': $translate.instant('button.validate'), 'onClick': validateForm }
-                ]
-            }
+            ] }
         ];
     }
 }

--- a/src/app/ui/summary/summary.directive.js
+++ b/src/app/ui/summary/summary.directive.js
@@ -35,13 +35,14 @@ function avSummary() {
     return directive;
 }
 
-function Controller($mdDialog, events, constants, modelManager) {
+function Controller($mdDialog, $rootScope, events, constants, modelManager) {
     'ngInject';
     const self = this;
 
     self.expandTree = expand;
     self.collapseTree = collapse;
     self.openPreview = openPreview;
+    self.validateForm = validateForm;
 
     // set tree directive tag
     self.tabs = constants.schemas.map(item => ({
@@ -74,6 +75,10 @@ function Controller($mdDialog, events, constants, modelManager) {
                 walkTree(tree[obj], key, value);
             }
         }
+    }
+
+    function validateForm() {
+        $rootScope.$broadcast(events.avValidateForm);
     }
 
     /**

--- a/src/app/ui/summary/summary.html
+++ b/src/app/ui/summary/summary.html
@@ -2,6 +2,12 @@
     <h1>{{ 'app.summary' | translate }}</h1>
     <md-button
         class="av-button-square md-raised"
+        ng-click="self.validateForm()">
+        {{ 'button.validate' | translate }}
+        <md-tooltip>{{ 'button.validate' | translate }}</md-tooltip>
+    </md-button>
+    <md-button
+        class="av-button-square md-raised"
         ng-click="self.expandTree()">
         {{ 'summary.expand' | translate }}
         <md-tooltip>{{ 'summary.expand' | translate }}</md-tooltip>


### PR DESCRIPTION
… instead of by form

Closes #66, #67

## Description
<!-- Link to an issue or include a description -->
Set show/hide advance configuration and form validation global instead of by form

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
chrome

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
Inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] ~~Release notes have been updated~~
- [x] PR targets the correct release version
- [ ] ~~Help files and documentation have been updated~~

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpa-apgf/76)
<!-- Reviewable:end -->
