### PR TITLE
fix(summary): enable summary expand and collapse

### DIFF
--- a/src/app/ui/summary/summary.directive.js
+++ b/src/app/ui/summary/summary.directive.js
@@ -59,8 +59,23 @@ function Controller($mdDialog, $rootScope, events, constants, modelManager, stat
     });
 
 
-    function expand() { walkTree(self, 'expand', true); }
-    function collapse() { walkTree(self, 'expand', false); }
+    function expand() { expandSummary(self, true); }
+    function collapse() { expandSummary(self, false); }
+
+    /**
+     * Expand or collapse the summary
+     *
+     * @function expandSummary
+     * @param {Object} summary summary object
+     * @param {Boolean} value Value to set
+     */
+    function expandSummary(summary, value) {
+        const arrSum = ['map', 'ui', 'services', 'version', 'language'];
+
+        for (let el of arrSum) {
+            walkTree(summary[el], 'expand', value);
+        }
+    }
 
     /**
      * Walk the tree to set expand or collapse
@@ -71,11 +86,12 @@ function Controller($mdDialog, $rootScope, events, constants, modelManager, stat
      * @param {Boolean} value Value to set
      */
     function walkTree(tree, key, value) {
-        for (let obj of tree) {
-            if (tree.hasOwnProperty(key)) { tree[key] = value; }
-            if (!!tree[obj] && typeof(tree[obj]) === 'object') {
-                if (tree.hasOwnProperty(key)) { tree[key] = value; }
-                walkTree(tree[obj], key, value);
+        if (tree.hasOwnProperty(key)) {
+            tree[key] = value;
+        }
+        if (tree.hasOwnProperty('items')) {
+            for (let item of tree.items) {
+                walkTree(item, key, value);
             }
         }
     }


### PR DESCRIPTION
Before: because of for-Of loop, walkTree function is not working and consequently the collapse and expand functions are not working either.
After: fix the for-Of loop inside walkTree. Expand and collapse are working properly.

Closes #152

## Description
<!-- Link to an issue or include a description -->

## Testing
Tested in Chrome
https://chrislatrncan.github.io/fgpa-apgf/samples/fgpv-author.html

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpa-apgf/154)
<!-- Reviewable:end -->
