### PR TITLE
feat(form): Add link dynamic select with fields from another form

### DIFF
--- a/src/app/core/constant.service.js
+++ b/src/app/core/constant.service.js
@@ -51,7 +51,8 @@ function events($rootScope) {
         avLoadModel: 'avLoadModel', // Fired when a user load an existing form
         avNewItems: 'avNewItems', // Fired when a user add a new item inside an array (e.g. layer of layers)
         avValidateForm: 'avValidateForm', // Fired when a user click on validate to validate all forms
-        avShowSplash: 'avShowSplash'
+        avShowSplash: 'avShowSplash',
+        avLayersIdUpdate: 'avLayersIdUpdate' // Fired when layers id is updated. Will be use inside UI model to update table layer id
     };
 }
 

--- a/src/app/ui/forms/form.service.js
+++ b/src/app/ui/forms/form.service.js
@@ -11,7 +11,7 @@ angular
     .module('app.ui')
     .factory('formService', formService);
 
-function formService($timeout, events, $mdDialog, $translate, commonService, constants, projectionService) {
+function formService($timeout, $rootScope, events, $mdDialog, $translate, commonService, constants, projectionService) {
 
     const service = {
         showAdvance,
@@ -357,14 +357,21 @@ function formService($timeout, events, $mdDialog, $translate, commonService, con
     * Array of keys made from key element
     * The same variable name created for the first element
     *
+    * For a sample with a broadcast event, look at avLayersIdupdateEvents
+    *
     * Known issue: onChange is not fired on the last item delete inside an array. Will need to find a workaround if need be
     * @function updateLinkValues
     * @param  {Object} scope  form scope
     * @param  {Array} keys the path to the key to get value from
     * @param  {String} link the value to update (need to be the same on optionData as the the field who receive the link)
+    * @param  {String} broadcast optional - the event to broadcast. This will be use to update link in another scope model
     */
-    function updateLinkValues(scope, keys, link) {
+    function updateLinkValues(scope, keys, link, broadcast = false) {
         scope[link] = findValues(scope.model, keys, 0, []);
+
+        if (broadcast !== false) {
+            $rootScope.$broadcast(events[broadcast], scope[link]);
+        }
     }
 
     /**

--- a/src/app/ui/forms/map/map.directive.js
+++ b/src/app/ui/forms/map/map.directive.js
@@ -73,6 +73,7 @@ function Controller($scope, $translate, $timeout,
         self.formService.updateLinkValues($scope, ['lodSets', 'id'], 'lodId');
         self.formService.updateLinkValues($scope, ['baseMaps', 'id'], 'initBaseId');
         self.formService.updateLinkValues($scope, ['tileSchemas', 'id'], 'tileId');
+        self.formService.updateLinkValues($scope, ['layers', 'id'], 'initLayerId', 'avLayersIdUpdate');
 
         $timeout(() => setCollapsibleHeader(), constants.delayCollapseLink);
 
@@ -464,7 +465,7 @@ function Controller($scope, $translate, $timeout,
                         { 'type': 'fieldset', 'htmlClass': 'av-accordion-toggle av-layer', 'title': $translate.instant('form.map.layer'), 'items': [
                             { 'key': 'layers[]', 'htmlClass': `av-accordion-content`, 'notitle': true, 'items': [
                                 { 'key': 'layers[].layerChoice', 'type': 'select' },
-                                { 'key': 'layers[].id' },
+                                { 'key': 'layers[].id', 'onChange': () => { debounceService.registerDebounce(self.formService.updateLinkValues($scope, ['layers', 'id'], 'initLayerId', 'avLayersIdUpdate'), constants.debInput, false); } },
                                 { 'key': 'layers[].name', 'targetLink': 'legend.0', 'targetParent': 'av-accordion-toggle', 'default': $translate.instant('form.map.layer'), 'onChange': debounceService.registerDebounce(self.formService.copyValueToFormIndex, constants.debInput, false) },
                                 { 'key': 'layers[].url' },
                                 { 'key': 'layers[].metadataUrl' },

--- a/src/app/ui/forms/ui/ui.directive.js
+++ b/src/app/ui/forms/ui/ui.directive.js
@@ -36,7 +36,7 @@ function avUi() {
     return directive;
 }
 
-function Controller($scope, $translate, events, modelManager, stateManager, formService) {
+function Controller($scope, $translate, $timeout, events, modelManager, stateManager, formService) {
     'ngInject';
     const self = this;
     self.modelName = 'ui';
@@ -59,6 +59,10 @@ function Controller($scope, $translate, events, modelManager, stateManager, form
     events.$on(events.avSwitchLanguage, () => {
         self.sectionName = $translate.instant('app.section.ui');
         init();
+    });
+
+    events.$on(events.avLayersIdUpdate, (evt, data) => {
+        $scope.initLayerId = data;
     });
 
     function init() {
@@ -128,7 +132,21 @@ function Controller($scope, $translate, events, modelManager, stateManager, form
                             { 'key': 'legend.isOpen' }
                         ]
                     },
-                    { 'key': 'tableIsOpen' }
+                    { 'key': 'tableIsOpen', 'items': [
+                        {
+                            'key': 'tableIsOpen.id',
+                            'type': 'dynamic-select',
+                            'optionData': 'initLayerId',
+                            'model': 'tableIsOpen_id',
+                            'array': false,
+                            // because the item is more then 1 level deep we need to define a temp model to link to the dynamic-select
+                            // this temp model will be save to config file as well use same name with _ to replace .
+                            'onChange': (model, data) => { $timeout(() => { $scope.model.tableIsOpen_id = model; $scope.model.tableIsOpen.id = model; }, 1000); }
+                        },
+                        { 'key': 'tableIsOpen.small' },
+                        { 'key': 'tableIsOpen.medium' },
+                        { 'key': 'tableIsOpen.large' }
+                    ] }
                 ] },
                 { 'title': $translate.instant('form.ui.appbar'), 'items': [
                     { 'key': 'appBar', 'notitle': true }

--- a/src/schemas/schemaForm/ui.en-CA.json
+++ b/src/schemas/schemaForm/ui.en-CA.json
@@ -246,7 +246,7 @@
             "properties": {
                 "id": {
                     "type": "string",
-                    "description": "The id of the layer for referencing within the viewer",
+                    "description": "The id of the layer for referencing within the viewer. Only works with feature layer.",
                     "title": "Layer ID",
                     "default": ""
                 },

--- a/src/schemas/schemaForm/ui.fr-CA.json
+++ b/src/schemas/schemaForm/ui.fr-CA.json
@@ -246,7 +246,7 @@
             "properties": {
                 "id": {
                     "type": "string",
-                    "description": "L'ID de la couche pour des fins de référencement à l'intérieur du visualisateur",
+                    "description": "L'ID de la couche pour des fins de référencement à l'intérieur du visualisateur. Fonctionne seulement avec des couches de type \"feature layer\"",
                     "title": "ID de la couche",
                     "default": ""
                 },


### PR DESCRIPTION
Closes #161

Link dynamic select with element from another form. As well, link dynamic select with element more then 1 level deep. Will be needed for the legend elements.

## Description
<!-- Link to an issue or include a description -->

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Chrome

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
Inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] ~~Release notes have been updated~~
- [x] PR targets the correct release version
- [ ] ~~Help files and documentation have been updated~~

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpa-apgf/162)
<!-- Reviewable:end -->
