### PR TITLE
add(core): process properties named value

### DIFF
--- a/src/app/core/common.service.js
+++ b/src/app/core/common.service.js
@@ -22,7 +22,8 @@ function commonService($translate, events) {
         getLang,
         setLangs,
         getLangs,
-        getUUID
+        getUUID,
+        getNested
     };
 
     let languages;
@@ -143,5 +144,22 @@ function commonService($translate, events) {
         }
 
         return (short) ? _p8() : `${_p8()}${_p8(true)}${_p8(true)}${_p8()}`;
+    }
+
+    /**
+     * Get object by array of keys representing a reference path
+     * eg: ['a', 'b', 'c'] => obj.a.b.c
+     * Source: http://blog.nicohaemhouts.com/2015/08/03/accessing-nested-javascript-objects-with-string-key/
+     * @function getNested
+     * @param {Object} obj object
+     * @param {String} path properties path
+     * @return {Object}  particular sub-object of an object or undefined
+     */
+    function getNested (obj, path) {
+        try {
+            return path.reduce(((o, property) => o[property]), obj);
+        } catch (err) {
+            return undefined;
+        }
     }
 }

--- a/src/app/ui/forms/services/services.directive.js
+++ b/src/app/ui/forms/services/services.directive.js
@@ -98,7 +98,7 @@ function Controller($scope, $translate, events, modelManager, stateManager, form
                     'key': 'export', 'items': [
                         { 'key': 'export.title', 'items': [
                             {
-                                'type': 'section', 'items': [{ 'key': 'export.title.value' }]
+                                'type': 'section', 'items': [{ 'key': 'export.title.titleValue' }]
                             },
                             {
                                 'type': 'section', 'items': [{ 'key': 'export.title.isSelected' }]
@@ -132,7 +132,7 @@ function Controller($scope, $translate, events, modelManager, stateManager, form
                             }
                         ] },
                         { 'key': 'export.footnote', 'items': [
-                            { 'key': 'export.footnote.value', 'notitle': true },
+                            { 'key': 'export.footnote.footnoteValue', 'notitle': true },
                             {
                                 'type': 'section', 'items': [{ 'key': 'export.footnote.isSelected' }]
                             },

--- a/src/content/samples/config/config-authorA.json
+++ b/src/content/samples/config/config-authorA.json
@@ -549,11 +549,19 @@
             "provinces": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
             "types": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
           }
+        },
+        "export": {
+          "title": {
+            "value": "This is a FGP demo"
+          },
+          "footnote": {
+            "value": "This is a footnote for FGP demo"
+          }
         }
     },
     "ui": {
         "sideMenu": {
-                "items": [["layers","basemap"],["fullscreen","export","share","touch","help","about"],["language"],["plugins"]]
-            }
+          "items": [["layers","basemap"],["fullscreen","export","share","touch","help","about"],["language"],["plugins"]]
+        }
     }
 }

--- a/src/schemas/schemaForm/services.en-CA.json
+++ b/src/schemas/schemaForm/services.en-CA.json
@@ -155,7 +155,7 @@
               "title": "Is customizable",
               "help": ""
             },
-            "value": {
+            "titleValue": {
               "type": "string",
               "description": "Value to appear by default",
               "title": "Value",
@@ -289,13 +289,13 @@
                 "title": "Is customizable",
                 "help": ""
               },
-            "value": {
-              "type": "string",
-              "description": "Value to appear by default",
-              "title": "",
-              "help": "",
-              "default": ""
-            }
+              "footnoteValue": {
+                "type": "string",
+                "description": "Value to appear by default",
+                "title": "Value",
+                "help": "",
+                "default": ""
+              }
           },
           "additionalProperties": false,
           "title": "Footnote",

--- a/src/schemas/schemaForm/services.fr-CA.json
+++ b/src/schemas/schemaForm/services.fr-CA.json
@@ -155,7 +155,7 @@
               "title": "Est personnalisable",
               "help": ""
             },
-            "value": {
+            "titleValue": {
               "type": "string",
               "description": "Valeur par défaut",
               "title": "Valeur",
@@ -289,10 +289,10 @@
                 "title": "Est personnalisable",
                 "help": ""
               },
-            "value": {
+            "footnoteValue": {
               "type": "string",
               "description": "Valeur par défaut",
-              "title": "",
+              "title": "Valeur",
               "help": "",
               "default": ""
             }


### PR DESCRIPTION
Before: value property has special meaning for Angular Schema Form.
In the summary, the title for value property does not display.
After: change value property name at load time and back to it's original value at save time.

Closes #129

## Description
<!-- Link to an issue or include a description -->

## Testing
Test with Chrome

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] ~~Release notes have been updated~~
- [x] PR targets the correct release version
- [ ] ~~Help files and documentation have been updated~~

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpa-apgf/171)
<!-- Reviewable:end -->
