### PR TITLE
add(feature): link preview, expand and collapse buttons with validation

### DIFF
--- a/src/app/core/constant.service.js
+++ b/src/app/core/constant.service.js
@@ -21,6 +21,7 @@ angular
         delaySplash: 3500,
         delayEventSplash: 750,
         delayUpdateColumns: 1000,
+        delaySetSubTab: 2000,
         delaySetVersion: 2000,
         delayScroll: 100,
         schemas: [

--- a/src/app/ui/forms/ui/ui.directive.js
+++ b/src/app/ui/forms/ui/ui.directive.js
@@ -42,10 +42,13 @@ function Controller($scope, $translate, $timeout, events, modelManager, stateMan
     self.modelName = 'ui';
     self.sectionName = $translate.instant('app.section.ui');
     self.formService = formService;
+    self.aboutContent = '';
+    self.aboutFile = '';
 
     // when schema is loaded or create new config is hit, initialize the schema, form and model
     events.$on(events.avSchemaUpdate, () => {
         $scope.model = modelManager.getModel(self.modelName);
+        getAboutChoice($scope.model);
         init();
     });
 
@@ -94,10 +97,27 @@ function Controller($scope, $translate, $timeout, events, modelManager, stateMan
 
                 // reset value to default because when we remove about from the array aboutChoice is emptied
                 $scope.model.about.aboutChoice = 'string';
-                $scope.model.about.content = '';
-                $scope.model.about.folderName = '';
+                $scope.model.about.content = self.aboutContent;
+                $scope.model.about.folderName = self.aboutFolder;
             }
         })
+    }
+
+    /**
+     * Set about content and file for persistence
+     * @function getAboutChoice
+     * @param {Object} model model
+     */
+    function getAboutChoice(model) {
+
+        if (model.hasOwnProperty('about')) {
+            // content
+            if (model.about.hasOwnProperty('content')) {
+                self.aboutContent = model.about.content;
+            } else { // file
+                self.aboutFile = model.about.aboutFolder;
+            }
+        }
     }
 
     function isHelp() {

--- a/src/app/ui/summary/summary.directive.js
+++ b/src/app/ui/summary/summary.directive.js
@@ -47,6 +47,9 @@ function Controller($mdDialog, $rootScope, $timeout, events, constants, modelMan
     self.collapseTree = collapse;
     self.openPreview = openPreview;
     self.validateForm = validateForm;
+    self.previewReady = previewReady;
+
+    self.disableCollapseExpand = true;
 
     // set tree directive tag
     self.tabs = constants.schemas.map(item => ({
@@ -58,13 +61,21 @@ function Controller($mdDialog, $rootScope, $timeout, events, constants, modelMan
     // on schema update, rebuild the tree (state object)
     events.$on(events.avSchemaUpdate, () => {
         initState();
-    });
-
-    events.$on(events.avSwitchLanguage, () => {
-        initState();
+        self.disableCollapseExpand = true;
         setSubTab(constants);
     });
 
+    // on switching language, rebuild the tree
+    events.$on(events.avSwitchLanguage, () => {
+        initState();
+        self.disableCollapseExpand = true;
+        setSubTab(constants);
+    });
+
+    // on validation enable expand and collapse
+    events.$on(events.avValidateForm, () => {
+        self.disableCollapseExpand = false;
+    });
 
     function expand() { expandSummary(self, true); }
     function collapse() { expandSummary(self, false); }
@@ -119,6 +130,15 @@ function Controller($mdDialog, $rootScope, $timeout, events, constants, modelMan
     }
 
     /**
+     * Check if preview can be done
+     * @function previewReady
+     * @return {Boolean} true if ready and false if not
+     */
+    function previewReady() {
+        return stateManager.goNoGoPreview();
+    }
+
+    /**
      * Open a dialog window to show current configuration
      * @function openPreview
      */
@@ -161,7 +181,7 @@ function Controller($mdDialog, $rootScope, $timeout, events, constants, modelMan
                 clearInterval(readyStateCheckInterval);
                 setSubTabID(constants);
             }
-        }, 1000);
+        }, constants.delaySetSubTab);
     }
 
     /**

--- a/src/app/ui/summary/summary.html
+++ b/src/app/ui/summary/summary.html
@@ -9,18 +9,21 @@
         </md-button>
         <md-button
             class="av-button-square md-raised"
+            ng-disabled="self.disableCollapseExpand"
             ng-click="self.expandTree()">
             {{ 'summary.expand' | translate }}
             <md-tooltip>{{ 'summary.expand' | translate }}</md-tooltip>
         </md-button>
         <md-button
             class="av-button-square md-raised"
+            ng-disabled="self.disableCollapseExpand"
             ng-click="self.collapseTree()">
             {{ 'summary.collapse' | translate }}
             <md-tooltip>{{ 'summary.collapse' | translate }}</md-tooltip>
         </md-button>
         <md-button
             class="av-button-square md-raised"
+            ng-disabled="!self.previewReady()"
             ng-click="self.openPreview()">
             {{ 'summary.preview' | translate }}
             <md-tooltip>{{ 'summary.preview' | translate }}</md-tooltip>

--- a/src/content/samples/config/config-authorA.json
+++ b/src/content/samples/config/config-authorA.json
@@ -586,6 +586,9 @@
     "ui": {
         "sideMenu": {
           "items": [["layers","basemap"],["fullscreen","export","share","touch","help","about"],["language"],["plugins"]]
+        },
+        "about": {
+          "content": "This is a FGP demo."
         }
     }
 }


### PR DESCRIPTION
Before:
- Preview button is enabled even if there is still validation errors
- Expand and collapse are enabled even before validation tree creation
- There is no about section in config-authorA
After:
- Preview button is disabled until there is no more validation error
- Expand and collapse are disabled until validation tree creation
- There is an about section in config-authorA

Closes #166

## Description
<!-- Link to an issue or include a description -->

## Testing
Test with Chrome and Fox

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] ~~Release notes have been updated~~
- [ ] PR targets the correct release version
- [x] ~~Help files and documentation have been updated~~

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpa-apgf/186)
<!-- Reviewable:end -->
