### PR TITLE
fix(summary): set sub-tab on user model loading

### DIFF
--- a/src/app/ui/summary/summary.directive.js
+++ b/src/app/ui/summary/summary.directive.js
@@ -72,6 +72,13 @@ function Controller($mdDialog, $rootScope, $timeout, $interval, events, constant
         setSubTab(constants);
     });
 
+    // on user model loading
+    events.$on(events.avLoadModel, () => {
+        initState();
+        self.disableCollapseExpand = true;
+        setSubTab(constants);
+    });
+
     // on validation enable expand and collapse
     events.$on(events.avValidateForm, () => {
         self.disableCollapseExpand = false;


### PR DESCRIPTION
Before: on user load model the validation won't work properly
Solution: catch the avLoadModel event in the summary and then create the subTab
After: on user load model the validation work properly

Closes #200

## Description
<!-- Link to an issue or include a description -->

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpa-apgf/201)
<!-- Reviewable:end -->
