### PR TITLE
fix(summary): validate form when preview is enable

### DIFF
--- a/src/app/core/constant.service.js
+++ b/src/app/core/constant.service.js
@@ -42,7 +42,7 @@ angular
             },
             services: {
                 index: 2,
-                keys: ['search', 'export', 'form.service.urls']
+                keys: ['export', 'search', 'form.service.urls']
             }
         }
     }); // TODO: add new tabs and subtabs as they come, tabs and subtabs listed as they should appear in the interface

--- a/src/app/ui/summary/summary.directive.js
+++ b/src/app/ui/summary/summary.directive.js
@@ -150,21 +150,27 @@ function Controller($mdDialog, $rootScope, $timeout, $interval, events, constant
      * @function openPreview
      */
     function openPreview() {
-        // set the config to use by the preview window/iFrame
-        localStorage.setItem('configpreview', modelManager.save(true));
 
-        // set the array of languages to use by the preview window/iFrame
-        const langs = commonService.setUniq([commonService.getLang()].concat(commonService.getLangs()));
-        localStorage.setItem('configlangs', `["${langs.join('","')}"]`);
+        validateForm();
 
-        $mdDialog.show({
-            controller: previewController,
-            controllerAs: 'self',
-            templateUrl: templateUrls.preview,
-            parent: $('.fgpa'),
-            clickOutsideToClose: true,
-            fullscreen: false
-        });
+        if (stateManager.goNoGoPreview()) {
+
+            // set the config to use by the preview window/iFrame
+            localStorage.setItem('configpreview', modelManager.save(true));
+
+            // set the array of languages to use by the preview window/iFrame
+            const langs = commonService.setUniq([commonService.getLang()].concat(commonService.getLangs()));
+            localStorage.setItem('configlangs', `["${langs.join('","')}"]`);
+
+            $mdDialog.show({
+                controller: previewController,
+                controllerAs: 'self',
+                templateUrl: templateUrls.preview,
+                parent: $('.fgpa'),
+                clickOutsideToClose: true,
+                fullscreen: false
+            });
+        }
     }
 
     function previewController($mdDialog) {


### PR DESCRIPTION
Before: when preview is enable and we insert an error in the form the preview is still enable.
Solution: validate the form on preview button click and disable preview if there is an error.
After: when preview is enable and we insert an error in the form the preview is disable on preview button click

Close #202

## Description
<!-- Link to an issue or include a description -->

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] ~~Release notes have been updated~~
- [x] PR targets the correct release version
- [ ] ~~Help files and documentation have been updated~~

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpa-apgf/239)
<!-- Reviewable:end -->
