### PR TITLE
feat(form): reorder array from keyboard

### DIFF
--- a/src/app/core/constant.service.js
+++ b/src/app/core/constant.service.js
@@ -14,6 +14,7 @@ angular
     .factory('appInfo', appInfo)
     .constant('constants', {
         debInput: 500, // time for debouncing when user enter value
+        delayWCAG: 250,
         delayAccordion: 2500,
         delayHandle: 3500,
         delayCollapseLink: 2800,

--- a/src/app/core/core.run.js
+++ b/src/app/core/core.run.js
@@ -17,6 +17,8 @@ angular
 const DEFAULT_LANGS = ['en-CA', 'fr-CA'];
 let languages = DEFAULT_LANGS;
 
+let activeElement;
+
 /**
  * Initialize author by setting the languages.
  * @function initLanguages
@@ -69,10 +71,21 @@ function loadExtensions($rootElement, $rootScope, externalService) {
 function initShortcut(keyNames, formService) {
     $('body').keydown(e => {
         // Alt-s/Alt-x can also be use to expand or collapse the collection
-        if (e.keyCode === keyNames.S && e.altKey || e.keyCode === keyNames.X && e.altKey)  {
+        if (e.which === keyNames.S && e.altKey || e.which === keyNames.X && e.altKey)  {
             const obj = { currentTarget: { parentElement: document.getElementsByClassName('av-layers')[0] } };
-            const collapse = (e.keyCode === keyNames.X) ? true : false;
+            const collapse = (e.which === keyNames.X) ? true : false;
             formService.toggleAll(obj, collapse);
+        }
+
+        // Alt-q/ to focus to summary panel
+        if (e.which === keyNames.Q && e.altKey)  {
+            activeElement = document.activeElement;
+            document.getElementsByClassName('av-summary-validate')[0].focus();
+            e.preventDefault();
+        }
+        if (e.which === keyNames.A && e.altKey)  {
+            if (typeof activeElement !== 'undefined') activeElement.focus();
+            e.preventDefault();
         }
     });
 }

--- a/src/app/core/external.service.js
+++ b/src/app/core/external.service.js
@@ -17,9 +17,11 @@ angular
  * @param  {Object} $rootScope top of the hierarchy of all scopes in an Angular app
  * @param  {Object} translations translation object that contains one property for every language Angular object
  * @param  {Object} $translate translate service Angular Object
+ * @param {Object} $timeout Angular timeout object
+ * @param {Object} constants service with all constants for the application
  * @return {Object} service
  */
-function externalService($mdDialog, $compile, $rootScope, translations, $translate) {
+function externalService($mdDialog, $compile, $rootScope, translations, $translate, $timeout, constants) {
 
     const service = {
         setExtensionDialog,
@@ -35,15 +37,19 @@ function externalService($mdDialog, $compile, $rootScope, translations, $transla
      * Set dialog box for extension
      * @function setExtensionDialog
      * @param  {String} template  template to use
+     * @param {String} classEl   the classes to use to get back to caller button
      */
-    function setExtensionDialog(template) {
+    function setExtensionDialog(template, classEl) {
         $mdDialog.show({
             controller: extensionDialogController,
             controllerAs: 'self',
             template: template,
             parent: $('.fgpa'),
             clickOutsideToClose: true,
-            fullscreen: false
+            fullscreen: false,
+            onRemoving: () => { $timeout(() => {
+                document.getElementsByClassName(classEl)[0].focus();
+            }, constants.delayWCAG); }
         });
 
         /**
@@ -67,10 +73,11 @@ function externalService($mdDialog, $compile, $rootScope, translations, $transla
      * @param  {String} click  function to call on cliclk event. Need to be added to the scope inside the extensions
      * @param  {String} label  label item to link to. Need to be added to translation insinde the extension (addTranslations)
      * @param  {String} tooltip  tooltip item to link to. Need to be added to translation insinde the extension (addTranslations)
+     * @param {String} classEl   the classes to add
      */
-    function addButton(element, addType, click, label, tooltip) {
+    function addButton(element, addType, click, label, tooltip, classEl) {
         element[addType]($compile(`<md-button
-            class="av-button-square md-raised"
+            class="av-button-square md-raised ${classEl}"
             ng-click="${click}">
             {{ 'extensions.${label}' | translate }}
             <md-tooltip>{{ 'extensions.${tooltip}' | translate }}</md-tooltip>

--- a/src/app/layout/dragHandle.directive.js
+++ b/src/app/layout/dragHandle.directive.js
@@ -18,16 +18,18 @@ angular
  * @function avDragHandle
  * @param {Object} $compile Angular object
  * @param {Object} $timeout Angular object
+ * @param  {Object} keyNames key names with corresponding key code
  * @param {Object} events Angular object
  * @param {Object} constants the modules whho contains all the constants
  * @return {Object}     directive body
  */
-function avDragHandle($compile, $timeout, events, constants) {
+function avDragHandle($compile, $timeout, keyNames, events, constants) {
     const directive = {
         restrict: 'A',
         link
     }
 
+    let timestamp = 0;
     let started = false;
 
     /**
@@ -46,27 +48,107 @@ function avDragHandle($compile, $timeout, events, constants) {
     }
 
     /**
-     * recreate the handle when model updated
+     * set the WCAG jQueryUi sortable
+     * @function setKeyboardReorder
+     * @private
+     * @param {Object} scope Angular scope to access to model element
+     */
+    function setKeyboardReorder(scope) {
+        // https://codepen.io/bartz/pen/rrgyjw
+        // extent jQueryUi to handle keyboard event
+        jQuery.fn.extend({
+            ksortable: function(options) {
+                this.sortable(options);
+
+                // select basemaps li not already setup and bind events
+                $('.av-baseMaps > ol > li:not([tabindex="0"])').attr('tabindex', 0)
+                    .bind('keydown', event => bindKeydown(event, scope.model.baseMaps));
+
+                // select layers li not already setup and bind events
+                $('.av-layers > ol > li:not([tabindex="0"])').attr('tabindex', 0)
+                    .bind('keydown', event => bindKeydown(event, scope.model.layers));
+
+                // select layer entries li not already setup and bind events
+                $('.av-layerEntries > ol > li:not([tabindex="0"])').attr('tabindex', 0)
+                    .bind('keydown', event => {
+                        const index = parseInt(document.activeElement.closest('.av-layer').getAttribute('sf-index'));
+                        bindKeydown(event, scope.model.layers[index].layerEntries);
+                    });
+
+            }
+        });
+
+        // sortOptions on form element doesn't seems to work. As a workaround, we set the sortOptions
+        // direclty on the element.
+        // for an array to be sortable, this needs to be present inside the array: { 'type': 'help', 'helpvalue': '<div class="av-drag-handle"></div>' }
+        // the class .av-sortable need to be present on the key e.g. 'key': 'layers', 'htmlClass': 'av-accordion-all av-layers av-sortable'
+        $('.av-sortable > .ui-sortable').ksortable({
+            'handle': 'div>div>.av-drag-handle>md-icon',
+            'placeholder': 'av-state-highlight',
+            'tolerance': 'pointer',
+            'containment': 'parent'
+        });
+    }
+
+    /**
+     * keyboard event to bind to li
+     * @function bindKeydown
+     * @private
+     * @param {Object} event triggered event
+     * @param {Array} list array of element to sort
+     */
+    function bindKeydown(event, list) {
+        // if the item is a groupitem and time elapse between event is more the 100 milliseconds
+        // we use a timestamp because event on layer entries is triggered twice each time
+        if (event.target.classList.contains('list-group-item') && event.timeStamp - timestamp > 100) {
+            const active = document.activeElement;
+            const index = parseInt(active.children[1].getAttribute('sf-index'));
+
+            // update index with the what it shuld become
+            let sort = 0;
+            if (event.which === keyNames.UP_ARROW) {
+                $(active).insertBefore($(active).prev());
+                sort = (index === 0) ? 0 : -1;
+            }
+            if (event.which === keyNames.DOWN_ARROW) {
+                $(active).insertAfter($(active).next());
+                sort = (index === list.length - 1) ? 0 : 1;
+            }
+
+            // swap items
+            [list[index], list[index + sort]] = [list[index + sort], list[index]];
+            active.focus();
+
+            // reset the sf-index on all array DOM elements
+            const lis = [...active.parentElement.children];
+            for (let [i, li] of lis.entries()) {
+                const sfIndexes = [...$(li).find('[sf-index]')];
+                for (let sf of sfIndexes) {
+                    sf.setAttribute('sf-index', i);
+                }
+            }
+        }
+
+        // set time stamp for next pass
+        timestamp = event.timeStamp;
+    }
+
+    /**
+     * recreate the handle when model update
      * @function setHandle
      * @param {Object} scope Angular object
      * @param {Object} element html element
      * @param {Object} delay timeout delay
      */
     function setHandle(scope, element, delay) {
+
         // drag handle is only inside map schema
         if (scope.schema.schema === 'map' && !started) {
             started = true;
 
-            // sortOptions on form element doesn't seems to work. As a workaround, we set the sortOptions
-            // direclty on the element.
-            // for an array to be sortable, this needs to be present inside the array: { 'type': 'help', 'helpvalue': '<div class="av-drag-handle"></div>' }
-            // the class .av-sortable need to be present on the key e.g. 'key': 'layers', 'htmlClass': 'av-accordion-all av-layers av-sortable'
-            $('.av-sortable > .ui-sortable').sortable({
-                'handle': 'div>div>.av-drag-handle>md-icon',
-                'placeholder': 'av-state-highlight',
-                'tolerance': 'pointer',
-                'containment': 'parent'
-            });
+            // set WCAG reorder
+            $timeout(() => { setKeyboardReorder(scope) }, delay);
+
             $timeout(() => {
                 element.find('.av-drag-handle').not(':has(>md-icon)').each((index, element) => {
                     addIcon($(element), scope);
@@ -77,6 +159,7 @@ function avDragHandle($compile, $timeout, events, constants) {
             $timeout(() => { started = false; }, 1000);
         }
     }
+
     /**
      * set the proper icon
      * @function addIcon

--- a/src/app/ui/forms/form.html
+++ b/src/app/ui/forms/form.html
@@ -1,6 +1,6 @@
 <div>
     <h3>{{ self.sectionName }}</h3>
-    <md-checkbox aria-label="{{ 'form.showadvance' | translate }}" class="md-primary"
+    <md-checkbox aria-label="{{ 'form.showadvance' | translate }}" class="md-primary av-show-advance"
         ng-model="self.formService.advanceModel"
         ng-change="self.formService.showAdvance()">
         {{ 'form.showadvance' | translate }}

--- a/src/app/ui/forms/map/map.directive.js
+++ b/src/app/ui/forms/map/map.directive.js
@@ -580,7 +580,7 @@ function Controller($scope, $translate, $timeout,
         const scope = $scope;
 
         return [
-            { 'type': 'tabs', 'tabs': [
+            { 'type': 'tabs', 'htmlClass': 'av-inner-tab', 'tabs': [
                 { 'title': $translate.instant('form.map.extentlods'), 'items': [
                     { 'type': 'template', 'template': self.formService.addCustomAccordion($translate.instant('form.custom.help'), `help/info-extentlods-${commonService.getLang()}.md`, true) },
                     { 'type': 'fieldset', 'htmlClass': 'av-form-advance hidden av-accordion-toggle av-collapse', 'title': $translate.instant('form.map.tileschema'), 'items': [
@@ -611,9 +611,9 @@ function Controller($scope, $translate, $timeout,
                     { 'type': 'fieldset', 'htmlClass': 'av-accordion-toggle av-collapse', 'title': $translate.instant('form.map.extentset'), 'items': [
                         { 'type': 'section', 'htmlClass': 'av-accordion-content', 'items': [
                             { 'key': 'extentSets', 'htmlClass': 'av-extentsets', 'onChange': () => self.formService.updateLinkValues(scope, [['extentSets', 'id']], 'extentId'), 'notitle': true, 'add': $translate.instant('button.add'), 'items': [
-                                { 'type': 'template', 'template': addButton('extentdefault', 'setExtent'), 'setExtent': () => self.formService.setExtent('default', $scope.model.extentSets) },
-                                { 'type': 'template', 'template': addButton('extentfull', 'setExtent'), 'setExtent': () => self.formService.setExtent('full', $scope.model.extentSets) },
-                                { 'type': 'template', 'template': addButton('extentmax', 'setExtent'), 'setExtent': () => self.formService.setExtent('maximum', $scope.model.extentSets) },
+                                { 'type': 'template', 'template': addButton('extentdefault', 'setExtent', 'av-setdefaultext-button'), 'setExtent': () => self.formService.setExtent('default', $scope.model.extentSets) },
+                                { 'type': 'template', 'template': addButton('extentfull', 'setExtent', 'av-setfullext-button'), 'setExtent': () => self.formService.setExtent('full', $scope.model.extentSets) },
+                                { 'type': 'template', 'template': addButton('extentmax', 'setExtent', 'av-setmaxext-button'), 'setExtent': () => self.formService.setExtent('maximum', $scope.model.extentSets) },
                                 { 'key': 'extentSets[].id', 'onChange': () => debounceService.registerDebounce(self.formService.updateLinkValues(scope, [['extentSets', 'id']], 'extentId'), constants.debInput, false) },
                                 { 'type': 'section', 'htmlClass': 'row', 'items': [
                                     { 'type': 'section', 'htmlClass': 'col-xs-2', 'items': [
@@ -696,7 +696,7 @@ function Controller($scope, $translate, $timeout,
                         { 'key': 'lodSets', 'htmlClass': 'av-accordion-content', 'onChange': () => self.formService.updateLinkValues($scope, [['lodSets', 'id']], 'lodId'), 'notitle': true, 'add': $translate.instant('button.add'), 'items': [
                             { 'key': 'lodSets[]', 'htmlClass': `av-lods-array`, 'items': [
                                 { 'key': 'lodSets[].id', 'onChange': () => debounceService.registerDebounce(self.formService.updateLinkValues($scope, [['lodSets', 'id']], 'lodId'), constants.debInput, false) },
-                                { 'type': 'template', 'template': addButton('setlods', 'setLods'), 'setLods': () => self.formService.setLods($scope.model.lodSets, self.formService.getActiveElemIndex('av-lods-array')) },
+                                { 'type': 'template', 'template': addButton('setlods', 'setLods', 'av-setloads-button'), 'setLods': () => self.formService.setLods($scope.model.lodSets, self.formService.getActiveElemIndex('av-lods-array')) },
                                 { 'type': 'fieldset', 'htmlClass': 'row', 'items': [
                                     { 'key': 'lodSets[].lods', 'add': null, 'items': [
                                         { 'type': 'section', 'htmlClass': 'row', 'readonly': true, 'items': [
@@ -1054,10 +1054,11 @@ function Controller($scope, $translate, $timeout,
      * @private
      * @param {String} type type of button to add
      * @param {String} func function to associate to ng-click
+     * @param {String} addClass class to add
      * @returns {String} the template for the button
      */
-    function addButton(type, func) {
-        return `<md-button class="av-button-square md-raised"
+    function addButton(type, func, addClass = '') {
+        return `<md-button class="av-button-square md-raised ${addClass}"
                         ng-click="form.${func}('${type}')">
                     {{ 'form.map.${type}' | translate }}
                     <md-tooltip>{{ 'form.map.${type}' | translate }}</md-tooltip>

--- a/src/app/ui/forms/services/services.directive.js
+++ b/src/app/ui/forms/services/services.directive.js
@@ -100,7 +100,7 @@ function Controller($scope, $translate, events, modelManager, stateManager, form
      */
     function setForm() {
         return [
-            { 'type': 'tabs', 'tabs': [
+            { 'type': 'tabs', 'htmlClass': 'av-inner-tab', 'tabs': [
                 { 'title': $translate.instant('form.service.export'), 'key': 'export', 'items': [
                     { 'key': 'export.title', 'items': [
                         { 'type': 'section', 'items': [{ 'key': 'export.title.titleValue' }] },

--- a/src/app/ui/forms/ui/ui.directive.js
+++ b/src/app/ui/forms/ui/ui.directive.js
@@ -216,7 +216,7 @@ function Controller($scope, $translate, $timeout, events, modelManager, stateMan
      */
     function setForm() {
         return [
-            { 'type': 'tabs', 'tabs': [
+            { 'type': 'tabs', 'htmlClass': 'av-inner-tab', 'tabs': [
                 { 'title': $translate.instant('form.ui.general'), 'items': [
                     { 'key': 'fullscreen' },
                     // FIXME: not use inside the viewer... see if still needed { 'key': 'theme' },

--- a/src/app/ui/header/header.directive.js
+++ b/src/app/ui/header/header.directive.js
@@ -183,7 +183,8 @@ function Controller($q, $mdDialog, $timeout, $rootElement, $http, events, modelM
                         templateUrl: templateUrls.error,
                         parent: $('.fgpa'),
                         clickOutsideToClose: true,
-                        fullscreen: false
+                        fullscreen: false,
+                        onRemoving: () => { document.getElementsByClassName('av-load-button')[0].focus(); }
                     });
 
                     function ErrorController($mdDialog) {
@@ -243,6 +244,7 @@ function Controller($q, $mdDialog, $timeout, $rootElement, $http, events, modelM
             locals: { name: self.saveName },
             onRemoving: element => {
                 self.saveName = document.getElementById('avInputFileSaveName').value;
+                document.getElementsByClassName('av-save-button')[0].focus();
             }
         });
     }
@@ -288,6 +290,7 @@ function Controller($q, $mdDialog, $timeout, $rootElement, $http, events, modelM
             } catch (e) {
                 self.error = $translate.instant('header.savedialog.error');
                 self.isError = true;
+                document.getElementsByClassName('av-savedialog-cancel')[0].focus();
             }
         }
 

--- a/src/app/ui/header/header.html
+++ b/src/app/ui/header/header.html
@@ -14,7 +14,7 @@
         <md-button
             translate
             aria-label="{{ 'header.help' | translate }}"
-            class="md-icon-button av-button-32 black"
+            class="md-icon-button av-button-32 black av-help-button"
             ng-click="self.help()">
             <md-tooltip>{{ 'header.help' | translate }}</md-tooltip>
             <md-icon md-svg-src="community:help"></md-icon>
@@ -42,7 +42,7 @@
         <md-button
             flow-init="{ singleFile: true, allowDuplicateUploads : true }"
             flow-files-submitted="self.filesSubmitted($files, $event, $flow)"
-            class="md-icon-button av-button-32 black"
+            class="md-icon-button av-button-32 black av-load-button"
             aria-label="{{ 'header.open' | translate }}"
             flow-btn
             flow-progress="console.log()"
@@ -54,7 +54,7 @@
         <md-button
             translate
             aria-label="{{ 'header.save' | translate }}"
-            class="md-icon-button av-button-32 black"
+            class="md-icon-button av-button-32 black av-save-button"
             ng-click="self.save()">
             <md-tooltip>{{ 'header.save' | translate }}</md-tooltip>
             <md-icon md-svg-src="content:save"></md-icon>

--- a/src/app/ui/header/help.service.js
+++ b/src/app/ui/header/help.service.js
@@ -88,7 +88,8 @@ function helpService($mdDialog, $translate, $timeout, translations, events, cons
             parent: ('.fgpa'),
             clickOutsideToClose: true,
             fullscreen: false,
-            onComplete: () => events.$broadcast(events.avShowHelp)
+            onComplete: () => events.$broadcast(events.avShowHelp),
+            onRemoving: () => { document.getElementsByClassName('av-help-button')[0].focus(); }
         });
     }
 

--- a/src/app/ui/header/save-dialog.html
+++ b/src/app/ui/header/save-dialog.html
@@ -7,14 +7,14 @@
             <div class="av-error">{{ self.error }}</div>
         </md-input-container>
         <md-button
-            class="av-button-square md-raised md-primary"
+            class="av-button-square md-raised md-primary av-savedialog-save"
             ng-click="self.save()"
             ng-disabled="self.fileName.length === 0 || self.isError === true">
             {{ 'button.save' | translate }}
             <md-tooltip>{{ 'button.save' | translate }}</md-tooltip>
         </md-button>
         <md-button
-            class="av-button-square md-raised"
+            class="av-button-square md-raised av-savedialog-cancel"
             ng-click="self.cancel()">
             {{ 'button.cancel' | translate }}
             <md-tooltip>{{ 'button.cancel' | translate }}</md-tooltip>

--- a/src/app/ui/summary/summary.directive.js
+++ b/src/app/ui/summary/summary.directive.js
@@ -197,7 +197,10 @@ function Controller($mdDialog, $rootScope, $timeout, $interval, events, constant
                 templateUrl: templateUrls.preview,
                 parent: $('.fgpa'),
                 clickOutsideToClose: true,
-                fullscreen: false
+                fullscreen: false,
+                onRemoving: () => { $timeout(() => {
+                    document.getElementsByClassName('av-preview-button')[0].focus();
+                }, constants.delayWCAG); }
             });
         }
     }

--- a/src/app/ui/summary/summary.html
+++ b/src/app/ui/summary/summary.html
@@ -2,7 +2,7 @@
     <h1>{{ 'app.summary' | translate }}</h1>
     <div class="av-summary-button">
         <md-button
-            class="av-button-square md-raised"
+            class="av-button-square md-raised av-summary-validate"
             ng-click="self.validateForm()">
             {{ 'button.validate' | translate }}
             <md-tooltip>{{ 'button.validate' | translate }}</md-tooltip>
@@ -22,7 +22,7 @@
             <md-tooltip>{{ 'summary.collapse' | translate }}</md-tooltip>
         </md-button>
         <md-button
-            class="av-button-square md-raised"
+            class="av-button-square md-raised av-preview-button"
             ng-disabled="!self.previewReady()"
             ng-click="self.openPreview()">
             {{ 'summary.preview' | translate }}

--- a/src/app/ui/tab/tab.directive.js
+++ b/src/app/ui/tab/tab.directive.js
@@ -37,10 +37,12 @@ function avTab() {
  *
  * @function Controller
  * @param {Object} $translate Angular translation object
+ * @param {Object} $timeout Angular timeout object
  * @param {Object} events Angular events object
+ * @param  {Object} keyNames key names with corresponding key code
  * @param {Object} constants service with all constants for the application
  */
-function Controller($translate, events, constants) {
+function Controller($translate, $timeout, events, keyNames, constants) {
     'ngInject';
     const self = this;
 
@@ -76,6 +78,24 @@ function Controller($translate, events, constants) {
         }
     }
 
-    function setTab(newTab) { self.tab = newTab; }
+    /**
+     * Select active tab
+     *
+     * @function setTab
+     * @private
+     * @param {Number} newTab the index of tab to select
+     * @param {Object} event the triggered event
+     */
+    function setTab(newTab, event = null) {
+        self.tab = newTab;
+
+        // WCAG
+        if (event === null || event.which === keyNames.SPACEBAR) {
+            $timeout(() => document.getElementsByClassName('av-show-advance')[newTab - 1].focus(), constants.delayWCAG);
+
+            if (event !== null) event.preventDefault();
+        }
+    }
+
     function isSet(tabNum) { return self.tab === tabNum; }
 }

--- a/src/app/ui/tab/tab.html
+++ b/src/app/ui/tab/tab.html
@@ -2,7 +2,7 @@
     <div flex="10">
         <ul class="av-main-tab nav nav-pills nav-stacked">
             <li class="{ active: self.isSet($index + 1) }" ng-repeat="tab in self.tabs">
-                <a href ng-click="self.setTab($index + 1)">{{ tab.name }}</a>
+                <a href ng-click="self.setTab($index + 1)" ng-keypress="self.setTab($index + 1, $event)">{{ tab.name }}</a>
             </li>
         </ul>
     </div>

--- a/src/content/samples/extensions/ddr/ddr.js
+++ b/src/content/samples/extensions/ddr/ddr.js
@@ -11,9 +11,9 @@ setTimeout(function() {
                         'title-style="title" title-value="{{ \'extensions.ddrtooltip\' | translate }}">' +
                     '<av-frame html="' + path + '/frame-ddr.html"></av-frame>' +
                 '</av-content-panel>' +
-            '</md-dialog>');
+            '</md-dialog>', 'av-ddr-button');
     }
 
     // add button to the interface
-    api.addButton($(document.getElementsByClassName('av-summary-button')), 'append', 'ddr()', 'ddrlabel', 'ddrtooltip');
+    api.addButton($(document.getElementsByClassName('av-summary-button')), 'append', 'ddr()', 'ddrlabel', 'ddrtooltip', 'av-ddr-button');
 }, 3000);

--- a/src/content/styles/vendor/_bootstrap.scss
+++ b/src/content/styles/vendor/_bootstrap.scss
@@ -12,6 +12,7 @@
 
     .list-group-item {
         padding: 0px 10px;
+        margin-bottom: 3px;
     }
 
     fieldset {

--- a/src/locales/help/en-CA.md
+++ b/src/locales/help/en-CA.md
@@ -322,7 +322,7 @@ options_ checkbox is not checked.
 Once all the configuration file fields pass validation, the Preview button ![](preview.png "Preview button") will be enabled.
 You will be then able to click this button to preview your configuration file in an instance of the FGPV application. This
 preview instance displays all the layers, basemaps, menus and options you have set as they would appear in a fully functional
-FGPV application. Note that any custom Help and About file content  cannot be displayed in the preview instance.
+FGPV application. Note that any custom Help and About file content cannot be displayed in the preview instance.
 
 The preview instance may require a few seconds to initialize depending on:
 + Network location
@@ -347,3 +347,8 @@ You will find the following FGPA application version information at the bottom o
 This page is WCAG 2.0 AA compliant.
 
 Keyboard Accessibility - Keyboard functionality is provided as an alternative for users who are unable to use a mouse. Use the Tab key to navigate forward to links and controls on the page. Press Shift+Tab to go back one step. Use the Enter or Spacebar keys to activate links and controls. Press Alt+s/Alt+x to expand or collapse the collection of layers.
+
+You can reorder the array of basemaps and layers from the keyboard. To do so, when focus is one of the array item container, press down arrow key to move it downward or press up arrow key to move it upward.
+
+You can focus directly to the Summary panel by pressing Alt+q. By pressing Alt+a, the focus will go back to the original
+element.

--- a/src/locales/help/fr-CA.md
+++ b/src/locales/help/fr-CA.md
@@ -126,7 +126,7 @@ Vous pouvez faire en sorte qu'une couche esriDynamic ressemble à une couche esr
 Cette option affichera une couche dynamique à une seule couche sans son groupe racine.
 
 En option, vous pouvez définir des valeurs d'URL pour les métadonnées et le catalogue pour afficher ces informations à l'intérieur
-du panneau de métadonnées accessible par  _Contrôle de la couche_ .
+du panneau de métadonnées accessible par _Contrôle de la couche_ .
 
 Pour chaque couche et entrées de couche, les options _Contrôle de la couche_ suivantes peuvent être sélectionnées:
 + Opacité (_opacity_)
@@ -368,3 +368,8 @@ Vous trouverez les informations suivantes sur la version de l'application APGF a
 Cette page respecte les règles pour l’accessibilité des contenus Web WCAG 2.0 AA.
 
 Accessibilité au clavier - La fonctionnalité du clavier est offerte en tant qu’alternative pour les utilisateurs qui sont dans l'impossibilité d’utiliser une souris. Utilisez la touche de tabulation pour naviguer vers les liens et les contrôles sur la page. Appuyez simultanément sur les touches « Majuscule+Tabulation » pour revenir un pas en arrière. Utilisez la touche « Entrée » ou la barre d’espacement pour activer les liens et les contrôles. Appuyez  simultanément sur les touches Alt+s/Alt+x pour ouvrir ou fermer le lot de couches.
+
+Vous pouvez réorganiser le tableau des cartes de fond et des couches à partir du clavier. Pour ce faire, lorsque le focus est sur l'un de ces éléments, appuyez sur la touche flèche vers le bas pour le déplacer vers le bas ou appuyez sur la touche flèche vers le haut pour le déplacer vers le haut.
+
+Vous pouvez focuser directement au panneau de sommaire en pressant Alt+q. En pressant Alt+a, le focus retournera
+à l'élément original.


### PR DESCRIPTION
Closes #362

## Description
<!-- Link to an issue or include a description -->
Fix WCAG issue
- Lost focus when dialog window close
- Double focus on tab element
- Click enter on tab will focus the first element
- Reorder basemaps, layers and layer entries
- Use alt\q to focus directly inside teh summary panel. Click alt\a to get back to caller

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Chrome

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
Update help file

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpa-apgf/364)
<!-- Reviewable:end -->
