### PR TITLE
fix(summary): scroll to item and show advance

### DIFF
--- a/src/app/core/common.service.js
+++ b/src/app/core/common.service.js
@@ -207,7 +207,7 @@ function commonService($translate, events, $timeout, constants) {
     function scrollToElement(id) {
         $timeout(() => {
             angular.element(`#${id}`)[0].scrollIntoView();
-        }, constants.delayScroll);
+        }, constants.delayScrollToElement);
     }
 
     /**

--- a/src/app/core/constant.service.js
+++ b/src/app/core/constant.service.js
@@ -25,6 +25,7 @@ angular
         delaySetSubTab: 100,
         delaySetVersion: 2000,
         delayScroll: 100,
+        delayScrollToElement: 300,
         supportWkid: [3978, 3857, 102100],
         schemas: [
             'map.[lang].json',

--- a/src/app/core/stateManager.service.js
+++ b/src/app/core/stateManager.service.js
@@ -48,7 +48,7 @@ function stateManager($timeout, $translate, events, constants, commonService, mo
             'expand': false,
             'masterlink': link,
             'hlink': link,
-            'advance': false,
+            'advance': 'falseHide',
             'stype': '',
             'shlink': '',
             items: [] };
@@ -222,17 +222,16 @@ function stateManager($timeout, $translate, events, constants, commonService, mo
         let finalAdv = cleanAdv.length > 0 ? cleanAdv.slice() : adv.slice();
         let finalAdvH = cleanAdvH.length > 0 ? cleanAdvH.slice() : advH.slice();
 
-        if (cleanAdvH.length > 0) {
-            // Remove hidden advance parameters from state tree
-            for (let item of finalAdvH) {
-                removeHiddenAdvance(_state[modelName], _state, item);
-            }
-        } else {
-            // Set special style to advance parameters to be shown
-            for (let item of finalAdv) {
-                setAdvance(_state[modelName], item);
-            }
+        // Set special style to advance parameters to be shown
+        for (let item of finalAdv) {
+            setAdvance(_state[modelName], item, 'trueShow');
         }
+
+        // Set special style to advance parameters to be shown
+        for (let item of finalAdvH) {
+            setAdvance(_state[modelName], item, 'trueHide');
+        }
+
 
     }
 
@@ -289,17 +288,18 @@ function stateManager($timeout, $translate, events, constants, commonService, mo
      * @private
      * @param {Object}  stateModel the stateModel
      * @param {Array}   keys keys
+     * @param {String}   value for style ['trueShow' | 'trueHide' | 'falseHide']
      */
-    function setAdvance(stateModel, keys) {
+    function setAdvance(stateModel, keys, value = 'trueShow') {
         if (stateModel.key === keys[0] && keys.length === 1) {
-            setStateValueDown(stateModel, 'advance', true);
+            setStateValueDown(stateModel, 'advance', value);
         } else {
             if (stateModel.key === keys[0] && keys.length > 1) {
                 keys.shift();
             }
             if (stateModel.hasOwnProperty('items')) {
                 for (let item of stateModel.items) {
-                    setAdvance(item, keys);
+                    setAdvance(item, keys, value);
                 }
             }
         }
@@ -475,7 +475,7 @@ function stateManager($timeout, $translate, events, constants, commonService, mo
                         'expand': false,
                         'masterlink': masterLink,
                         'hlink': hlink,
-                        'advance': false,
+                        'advance': 'falseHide',
                         'stype': stype,
                         'shlink': shlink,
                         'type': 'object' });
@@ -524,7 +524,7 @@ function stateManager($timeout, $translate, events, constants, commonService, mo
                         'expand': false,
                         'masterlink': masterLink,
                         'hlink': hlink,
-                        'advance': false,
+                        'advance': 'falseHide',
                         'stype': stype,
                         'shlink': '',
                         'type': 'object' });
@@ -827,7 +827,7 @@ function stateManager($timeout, $translate, events, constants, commonService, mo
                         'expand': false,
                         'masterlink': mainSection,
                         'hlink': hlink,
-                        'advance': false,
+                        'advance': 'falseHide',
                         'stype': '',
                         'shlink': '',
                         'type': 'object' });
@@ -858,7 +858,7 @@ function stateManager($timeout, $translate, events, constants, commonService, mo
                         'expand': false,
                         'masterlink': mainSection,
                         'hlink': hlink,
-                        'advance': false,
+                        'advance': 'falseHide',
                         'stype': '',
                         'shlink': '',
                         'type': 'object' });

--- a/src/app/ui/forms/form.html
+++ b/src/app/ui/forms/form.html
@@ -2,7 +2,7 @@
     <h3>{{ self.sectionName }}</h3>
     <md-checkbox aria-label="{{ 'form.showadvance' | translate }}" class="md-primary av-show-advance"
         ng-model="self.formService.advanceModel"
-        ng-change="self.formService.showAdvance()">
+        ng-change="self.formService.showAdvance();self.formService.triggerValidation();">
         {{ 'form.showadvance' | translate }}
     </md-checkbox>
     <form class="av-main-form av-form-{{ self.modelName }}" name="activeForm" sf-schema="schema" sf-form="form"

--- a/src/app/ui/forms/form.service.js
+++ b/src/app/ui/forms/form.service.js
@@ -40,6 +40,7 @@ function formService($timeout, $rootScope, events, $mdDialog, $translate, keyNam
 
     const service = {
         showAdvance,
+        triggerValidation,
         advanceModel: false,
         toggleSection,
         toggleAll,
@@ -125,6 +126,17 @@ function formService($timeout, $rootScope, events, $mdDialog, $translate, keyNam
 
         const func = (service.advanceModel) ? 'removeClass' : 'addClass';
         $(elems)[func]('hidden');
+    }
+
+    /**
+     * Trigger forms validation
+     *
+     * @function triggerValidation
+     */
+    function triggerValidation() {
+        $timeout(() => {
+            angular.element('#validate').triggerHandler('click');
+        });
     }
 
     /**

--- a/src/app/ui/summary/summary.html
+++ b/src/app/ui/summary/summary.html
@@ -2,6 +2,7 @@
     <h1>{{ 'app.summary' | translate }}</h1>
     <div class="av-summary-button">
         <md-button
+            id = "validate"
             class="av-button-square md-raised av-summary-validate"
             ng-click="self.validateForm()">
             {{ 'button.validate' | translate }}

--- a/src/app/ui/tree/tree.html
+++ b/src/app/ui/tree/tree.html
@@ -4,7 +4,7 @@
     <md-icon class="av-summary-icon" md-svg-src="hardware:keyboard_arrow_right"  ng-click="tree.expand = !tree.expand;" ng-if="!tree.expand && tree.items.length"></md-icon>
     <md-icon class="av-summary-icon av-good" md-svg-src="action:check_circle" ng-if="tree.valid === true"></md-icon>
     <md-icon class="av-summary-icon av-alert" md-svg-src="alert:error" ng-if="tree.valid === false"></md-icon>
-    <span class="node.selected" ng-class="{'av-summary-adv': tree.advance === true, 'av-summary-list': tree.stype === 'element', 'av-summary-bad': tree.stype === 'bad-element'}" ng-click="self.setFocus(tree)">{{ tree.title }}</span>
+    <span class="node.selected" ng-class="{'av-summary-adv': tree.advance === 'trueShow', 'av-summary-advlight': tree.advance === 'trueHide', 'av-summary-list': tree.stype === 'element', 'av-summary-bad': tree.stype === 'bad-element'}" ng-click="self.setFocus(tree)">{{ tree.title }}</span>
     <li ng-repeat="item in tree.items" ng-if="tree.expand">
         <div><av-tree tree="item"></av-tree></div>
     </li>

--- a/src/content/styles/modules/_summary.scss
+++ b/src/content/styles/modules/_summary.scss
@@ -24,6 +24,11 @@
         font-style: italic;
     }
 
+    .av-summary-advlight {
+        font-style: italic;
+        opacity: 0.5;
+    }
+
     .av-summary-list  {
         color: $focus-color;
     }


### PR DESCRIPTION
Before:
- scroll to element from summary panel not working
- advance parameters not in summary tree if show advanced set to false
After:
- add delay to scroll timeout to let WCAG stuff execution.
- let hide advance items in the summary tree. Give them special styles.

Closes #344

## Description
<!-- Link to an issue or include a description -->

## Testing
Chrome, Fox

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [ ] ~~Help files and documentation have been updated~~

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpa-apgf/374)
<!-- Reviewable:end -->
