### PR TITLE
fix(layer): esriFeature doesn't work in 3.0

### DIFF
--- a/src/schemas/schemaForm/map.en-CA.json
+++ b/src/schemas/schemaForm/map.en-CA.json
@@ -638,7 +638,7 @@
                       "type": "string",
                       "enum": [ "csv", "geojson", "shapefile" ],
                       "title": "File type",
-                      "default": "csv",
+                      "default": "",
                       "required": true
                     },
                     "colour": {

--- a/src/schemas/schemaForm/map.fr-CA.json
+++ b/src/schemas/schemaForm/map.fr-CA.json
@@ -639,7 +639,7 @@
                       "type": "string",
                       "enum": [ "csv", "geojson", "shapefile" ],
                       "title": "Sélecteur de type de fichier",
-                      "default": "csv",
+                      "default": "",
                       "required": true
                     },
                     "colour": {


### PR DESCRIPTION
Closes #464

## Description
The geoApi when filetype with a value is present tries to set it up. In our schema we have items even if they are not needed for the layer type. Removing the default value for filetype does the job.

## Testing

## Documentation

## Checklist

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpa-apgf/467)
<!-- Reviewable:end -->
